### PR TITLE
BREAKING: Switch to "Samples-style"

### DIFF
--- a/CSV_FORMAT.md
+++ b/CSV_FORMAT.md
@@ -1,15 +1,14 @@
-# Universal Data Tool Format (*.udt.csv) Specification
+# Universal Data Tool Format (\*.udt.csv) Specification
 
 A `*.udt.csv` file is a [CSV](https://tools.ietf.org/html/rfc4180) representation of a Universal Data Tool interface, sample data and labels.
 
 A `*.udt.csv` file can be used the same way as a `*.udt.json` file. An example `*.udt.csv` file is show below:
 
 | path      | .                                                                                                                                 | imageUrl                                                                              | output | output.regionType | output.centerX    | output.centerY    | output.width      | output.height     | output.classification | output.labels | output.color      |
-|-----------|-----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|--------|-------------------|-------------------|-------------------|-------------------|-------------------|-----------------------|---------------|-------------------|
+| --------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------ | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | --------------------- | ------------- | ----------------- |
 | interface | {"type":"image_segmentation","availableLabels":["valid","invalid"],"regionTypesAllowed":["bounding-box"],"multipleRegions":false} |                                                                                       |        |                   |                   |                   |                   |                   |                       |               |                   |
 | samples.0 |                                                                                                                                   | https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image1.jpg |        | bounding-box      | 0.284214473190851 | 0.331271091113611 | 0.364454443194601 | 0.111361079865017 | valid                 |               | hsl(185,100%,50%) |
 | samples.1 |                                                                                                                                   | https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image2.jpg | null   |                   |                   |                   |                   |                   |                       |               |                   |
-
 
 A UDT CSV has one or more rows containing metadata, in the example above, we can see the `interface` row has some information regarding how to construct the interface to edit the samples.
 

--- a/SAMPLE.udt.json
+++ b/SAMPLE.udt.json
@@ -7,15 +7,17 @@
   "samples": [
     {
       "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image1.jpg",
-      "output": {
-        "regionType": "bounding-box",
-        "centerX": 0.2919799498746867,
-        "centerY": 0.3317669172932331,
-        "width": 0.3634085213032581,
-        "height": 0.09962406015037595,
-        "classification": "valid",
-        "color": "hsl(105,100%,50%)"
-      }
+      "output": [
+        {
+          "regionType": "bounding-box",
+          "centerX": 0.2919799498746867,
+          "centerY": 0.3317669172932331,
+          "width": 0.3634085213032581,
+          "height": 0.09962406015037595,
+          "classification": "valid",
+          "color": "hsl(105,100%,50%)"
+        }
+      ]
     },
     {
       "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image2.jpg",

--- a/SAMPLE.udt.json
+++ b/SAMPLE.udt.json
@@ -1,27 +1,13 @@
 {
   "interface": {
     "type": "image_segmentation",
-    "availableLabels": [
-      "valid",
-      "invalid"
-    ],
-    "regionTypesAllowed": [
-      "bounding-box",
-      "polygon",
-      "point"
-    ]
+    "availableLabels": ["valid", "invalid"],
+    "regionTypesAllowed": ["bounding-box", "polygon", "point"]
   },
-  "taskData": [
+  "samples": [
     {
-      "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image1.jpg"
-    },
-    {
-      "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image2.jpg"
-    }
-  ],
-  "taskOutput": [
-    [
-      {
+      "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image1.jpg",
+      "output": {
         "regionType": "bounding-box",
         "centerX": 0.2919799498746867,
         "centerY": 0.3317669172932331,
@@ -30,7 +16,10 @@
         "classification": "valid",
         "color": "hsl(105,100%,50%)"
       }
-    ],
-    null
+    },
+    {
+      "imageUrl": "https://s3.amazonaws.com/asset.workaround.online/example-jobs/sticky-notes/image2.jpg",
+      "output": null
+    }
   ]
 }

--- a/interfaces/audio_transcription.md
+++ b/interfaces/audio_transcription.md
@@ -2,7 +2,7 @@
 
 The `audio_transcription` interface allows you to convert audio into transcribed text.
 
-* Markdown description containing images, links or instructions. Per-task and/or universal description.
+- Markdown description containing images, links or instructions. Per-task and/or universal description.
 
 ## Schema
 
@@ -16,12 +16,14 @@ The `audio_transcription` interface allows you to convert audio into transcribed
     "onlyUseWordsInPhraseBank": boolean, // defaults to false
     "transcriptionType": "simple" | "proper" //defaults to simple
   },
-  "taskData": [
-    { audioUrl: "https://...." }
+  "samples": [
+    {
+      audioUrl: "https://...."
+    }
   ],
   "examples": [
     {
-      data: { audioUrl: "https://..." },
+      audioUrl: "https://...",
       output: "..."
     }
   ]
@@ -34,13 +36,12 @@ Each task output is a string representation of an audio file. The output format 
 
 ## Simple Transcription Type
 
-* All numbers written in their full string form. e.g. 100 is written one hundred. This is because numbers can be pronounced in different ways, e.g. one thousand five hundred and fifteen hundred. [There are libraries to convert number words to numbers](https://pypi.org/project/word2number/)
-* All characters are lower case.
-* In general, punctuation such as commas, hyphens, apostrophes and ellipses are not present. Periods and question marks should be kept. If a hyphen-word is used, a dash "-" should be used instead of a unicode hyphen "‐"
-* If a letter is spoken e.g. "ABC" it's written as "ABC"
-* Space after every comma
-* All sentences have a period
-
+- All numbers written in their full string form. e.g. 100 is written one hundred. This is because numbers can be pronounced in different ways, e.g. one thousand five hundred and fifteen hundred. [There are libraries to convert number words to numbers](https://pypi.org/project/word2number/)
+- All characters are lower case.
+- In general, punctuation such as commas, hyphens, apostrophes and ellipses are not present. Periods and question marks should be kept. If a hyphen-word is used, a dash "-" should be used instead of a unicode hyphen "‐"
+- If a letter is spoken e.g. "ABC" it's written as "ABC"
+- Space after every comma
+- All sentences have a period
 
 ```
 // Example Simple Transcription Strings
@@ -51,6 +52,6 @@ there are one hundred ways to make a mistake.
 
 ## Proper Transcription Type
 
-* All numbers written in their full string form. e.g. 100 is written one hundred. This is because numbers can be pronounced in different ways, e.g. one thousand five hundred and fifteen hundred. [There are libraries to convert number words to numbers](https://pypi.org/project/word2number/)
-* Sentences are capitalized. Proper nouns are capitalized.
-* Commas and other punctuation is used appropriately and sometimes ambiguously.
+- All numbers written in their full string form. e.g. 100 is written one hundred. This is because numbers can be pronounced in different ways, e.g. one thousand five hundred and fifteen hundred. [There are libraries to convert number words to numbers](https://pypi.org/project/word2number/)
+- Sentences are capitalized. Proper nouns are capitalized.
+- Commas and other punctuation is used appropriately and sometimes ambiguously.

--- a/interfaces/composite.md
+++ b/interfaces/composite.md
@@ -8,7 +8,7 @@ Use the `composite` interface type to combine several interfaces together.
 {
   "interface": {
     "type": "composite",
-    
+
     "fields": [
       {
         "fieldName": "some_field_name",
@@ -16,7 +16,7 @@ Use the `composite` interface type to combine several interfaces together.
       }
     ]
   },
-  "taskData": [
+  "samples": [
     {
       /*
         Any applicable task data for the defined interfaces
@@ -25,8 +25,8 @@ Use the `composite` interface type to combine several interfaces together.
   },
   "examples": [
     {
-      /* ... same information as taskData ... */
-      
+      /* ... same information as samples ... */
+
       // Expected output
       "output": {
         // Each key is a fieldName, the output is the output from that interface

--- a/interfaces/data_entry.md
+++ b/interfaces/data_entry.md
@@ -2,9 +2,9 @@
 
 The `data_entry` interface allows you to collect data using a form. It's ideal for many data entry, classification or research purposes.
 
-* Markdown description containing images, links or instructions. Per-task and/or universal description.
-* Create a custom `surveyjs` JSON file. [This tool from surveyjs.io is very helpful](https://surveyjs.io/create-survey/). To manually create the object, [reference this specification](https://github.com/CollegeAI/material-survey/blob/master/docs/material-survey-format.md).
-* PDF URLs, Image URLs, External Site URL or markdown description for each task.
+- Markdown description containing images, links or instructions. Per-task and/or universal description.
+- Create a custom `surveyjs` JSON file. [This tool from surveyjs.io is very helpful](https://surveyjs.io/create-survey/). To manually create the object, [reference this specification](https://github.com/CollegeAI/material-survey/blob/master/docs/material-survey-format.md).
+- PDF URLs, Image URLs, External Site URL or markdown description for each task.
 
 ## Schema
 
@@ -15,7 +15,7 @@ The `data_entry` interface allows you to collect data using a form. It's ideal f
     "description"?: MarkdownDescription,
     "surveyjs": SurveyJSObject
   },
-  "taskData": [
+  "samples": [
     // These are all different types of task data that are acceptable
     { pdfUrl: "https://..." },
     { markdown: "## Some Content" },
@@ -26,12 +26,13 @@ The `data_entry` interface allows you to collect data using a form. It's ideal f
   ],
   "examples": [
     {
-      data: { pdfUrl: "https://..." },
+      pdfUrl: "https://...",
       output: { "FieldName": "..." }
     }
   ]
 }
 ```
+
 ## Output
 
 The output of data entry tasks is given by SurveyJS. Check the "Test Survey" tab using the [SurveyJS tool](https://surveyjs.io/create-survey/).

--- a/interfaces/image_label.md
+++ b/interfaces/image_label.md
@@ -10,7 +10,7 @@ For complex answer logic, text questions, and multiple simultaneous classificati
 {
   "interface": {
     "type": "image_label",
-  
+
     // A list of labels available
     "availableLabels": ["human", "dog", "cat"],
     /* Also valid:
@@ -21,22 +21,22 @@ For complex answer logic, text questions, and multiple simultaneous classificati
      ]
     */
   },
-  "taskData": [
+  "samples": [
     {
       // URL pointing to image
       "imageUrl": "https://...",
 
       // Path to image. Available if upload is zip.
       "imagePath": "imgs/myimage1.jpg"
-      
+
       // Region to be labeled (if not specified, entire image is labeled)
       "region": {/* determined by regionFormat */}
     }
   },
   "examples": [
     {
-      /* ... same information as taskData ... */
-      
+      /* ... same information as samples ... */
+
       // Expected output
       "output": "label"
     }

--- a/interfaces/image_segmentation.md
+++ b/interfaces/image_segmentation.md
@@ -8,7 +8,7 @@
 {
   "interface": {
     "type": "image_segmentation",
-  
+
     // A list of labels available
     "availableLabels": ["human", "dog", "cat"],
     /* Also valid:
@@ -18,29 +18,29 @@
       { "id": "cat", "name": "Cat", "description": "Furry creature with whiskers" }
      ],
     */
-    
+
     // Optional: The type of region allowed. By default, any region is acceptable.
     "regionTypesAllowed": ["bounding-box", "polygon", "full-segmentation", "point", "pixel-mask"],
-        
+
     // What does the region represent?
     "regionDescription": "faces",
-    
+
     // Should there be multiple classifications for each region?
     "multipleRegionLabels": false,
-    
+
     // Should multiple regions be created?
     "multipleRegions": true,
-    
+
     // What is the smallest allowed area per region as a percentage of the image area?
     "minimumRegionSize": 0.01,
-    
+
     // Are regions allowed to overlap?
     "overlappingRegions": true,
-    
+
     // For a region to be acceptable, how much overlap should it have with the solution set?
     "regionMinAcceptableDifference": 0.1
   },
-  "taskData": [
+  "samples": [
     {
       // URL pointing to image
       "imageUrl": "https://..."
@@ -56,7 +56,7 @@
   },
   "examples": [
     {
-      "data": : { "imageUrl": "https://..." },
+      "imageUrl": "https://...",
       // Can be array or object depending on the value of `interface.multipleRegions`
       "output": [{/* Shape */}]
     }
@@ -68,13 +68,13 @@
 
 Different regions have different JSON representations. All the numbers are represented as a percentage of the image width and height, not as pixels. Using the image width and height, they can easily be converted to pixels.
 
-| Region | Description | JSON Representation |
-| ------ | ----------- | ------------------- |
-| `bounding-box` | Rectangle | `{ regionType: "bounding-box", centerX, centerY, width, height }` |
-| `point` | Point | `{regionType: "point", x, y }` |
-| `polygon` | Closed polygon | `{regionType: "polygon", points: [{x,y}, {x,y}, ...] }` |
-| `line` | Line made up of points | `{regionType: "line", points: [{x,y}, {x,y}, ...] }}` |
-| `pixel-mask` | A 2d matrix where each cell represents a classification | `{regionType: "pixel-mask", matrix: [[0,0,1,1,1, ...], [0,0,1,1,1, ...], [0,0,1,1,1,...], ...], centerX, centerY, width, height, classifications: ["someRegionId", ...] }}` |
+| Region         | Description                                             | JSON Representation                                                                                                                                                         |
+| -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bounding-box` | Rectangle                                               | `{ regionType: "bounding-box", centerX, centerY, width, height }`                                                                                                           |
+| `point`        | Point                                                   | `{regionType: "point", x, y }`                                                                                                                                              |
+| `polygon`      | Closed polygon                                          | `{regionType: "polygon", points: [{x,y}, {x,y}, ...] }`                                                                                                                     |
+| `line`         | Line made up of points                                  | `{regionType: "line", points: [{x,y}, {x,y}, ...] }}`                                                                                                                       |
+| `pixel-mask`   | A 2d matrix where each cell represents a classification | `{regionType: "pixel-mask", matrix: [[0,0,1,1,1, ...], [0,0,1,1,1, ...], [0,0,1,1,1,...], ...], centerX, centerY, width, height, classifications: ["someRegionId", ...] }}` |
 
 If `multipleRegions` is `true`, then regions in the input and output are expressed as arrays.
 

--- a/interfaces/text_classification.md
+++ b/interfaces/text_classification.md
@@ -2,9 +2,9 @@
 
 Categorize text.
 
-* Markdown instruction containing instructions
-* List of categories with descriptions
-* Classify into one or more categories.
+- Markdown instruction containing instructions
+- List of categories with descriptions
+- Classify into one or more categories.
 
 ## Schema
 
@@ -27,19 +27,20 @@ Categorize text.
       }
     ]
   },
-  "taskData": [
+  "samples": [
     // These are all different types of task data that are acceptable
     {
-      "document": "Harry"
+      "document": "Harry",
     },
     {
-      "document": "Malfoy"
+      "document": "Malfoy",
     }
   ],
-  // After completion...
-  "taskOutput": [
-    { "label": "gryffindor" },
-    { "label": "slytherin" }
+  "examples": [
+    {
+      // same as samples...
+      output: { "label": "gryffindor" }
+    }
   ]
 }
 ```

--- a/interfaces/text_entity_recognition.md
+++ b/interfaces/text_entity_recognition.md
@@ -2,8 +2,8 @@
 
 Label named entities in text.
 
-* Markdown instruction containing instructions.
-* List of entities with descriptions.
+- Markdown instruction containing instructions.
+- List of entities with descriptions.
 
 ## Schema
 
@@ -26,17 +26,20 @@ Label named entities in text.
       }
     ]
   },
-  "taskData": [
+  "samples": [
     {
-      "document": "This strainer makes a great hat, I'll wear it while I serve spaghetti!"
+      "document": "This text document is broken into selectable chunks."
     }
   ],
   // OPTIONAL
-  "taskOutput": [
-    "entities": [
-      { text: "strainer", label: "hat", start: 5, end: 13 },
-      { text: "spaghetti", label: "food", start: 60, end: 69 }
-    ]
+  "examples": [
+    "document": "This strainer makes a great hat, I'll wear it while I serve spaghetti",
+    "output": {
+      "entities": [
+        { text: "strainer", label: "hat", start: 5, end: 13 },
+        { text: "spaghetti", label: "food", start: 60, end: 69 }
+      ]
+    }
   ]
 }
 ```

--- a/interfaces/video_segmentation.md
+++ b/interfaces/video_segmentation.md
@@ -1,7 +1,5 @@
 # Video Segmentation
 
-> ***Unstable*** This is currently a draft
-
 The `video_segmentation` interface allows you to classify videos or place bounding boxes, polygons or regions with labels on a video.
 
 ## Schema
@@ -21,40 +19,37 @@ The `video_segmentation` interface allows you to classify videos or place boundi
       { "id": "cat", "name": "Cat", "description": "Furry creature with whiskers" }
      ],
     */
-    
+
     // Optional: The type of region allowed. By default, any region is acceptable.
     "regionTypesAllowed": ["bounding-box", "polygon", "full-segmentation", "point", "pixel-mask"],
-        
+
     // What does the region represent?
     "regionDescription": "faces",
-    
+
     // Should there be multiple classifications for each region?
     "multipleRegionLabels": false,
-    
+
     // Should multiple regions be created?
     "multipleRegions": true,
-    
+
     // What is the smallest allowed area per region as a percentage of the image area?
     "minimumRegionSize": 0.01,
-    
+
     // Are regions allowed to overlap?
     "overlappingRegions": true,
-    
+
     // For a region to be acceptable, how much overlap should it have with the solution set?
     "regionMinAcceptableDifference": 0.1
   },
-  "taskData": [
+  "samples": [
     // These are all different types of task data that are acceptable
     { videoUrl: "https://..." }
   ],
   "examples": [
     {
-      data: { videoUrl: "https://..." },
+      videoUrl: "https://...",
       output: [/** Regions **/]
     }
   ]
 }
 ```
-## Output
-
-TODO


### PR DESCRIPTION
This will hopefully be the only big breaking change we need to do. When I originally came up with this format I thought it would be a good idea to separate `taskData` and `taskOutput` to make it clear what work was performed and what the input data was. In practice, I don't see a need for this distinction and it makes indexing a pain. This change makes the JSON more consistent with the CSV representation and the representation of other libraries by removing `taskData` and `taskOutput` and creating a `samples` array which contains both input data and output data.

"output" is not quite a perfect name, but neither is "label". "annotations" is slightly more fitting but confusing in the case where image classifications have string as an output. So in short, I think "output" is general enough to cover all the cases.

```javascript
// OLD WAY
{
  "taskData": [
     { "imageUrl": "https://..." },
     { "imageUrl": "https://..." }
  ],
  "taskOutput": [
     "cat",
     "dog"
  ]
}
// NEW WAY
{
  "samples": [
     {
        "imageUrl": "https://...",
        "output": "cat"
     },
     {
        "imageUrl": "https://...",
        "output": "dog"
     }
  ]
}

```